### PR TITLE
Update send_to_maya.py

### DIFF
--- a/lib/send_to_maya.py
+++ b/lib/send_to_maya.py
@@ -39,7 +39,7 @@ def SendToMaya(options):
     client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     client.connect(ADDR)
 
-    client.send(command_tpl)
+    client.send(command_tpl.encode('utf-8'))
     data = client.recv(1024)
 
     print(data)


### PR DESCRIPTION
Improper encoding of message with Python 3.5. Requires bytes now instead of string. Adding this simple utf-8 encoding fixes error.